### PR TITLE
upcoming p8_ asm symbol prefixing 

### DIFF
--- a/c64/keyboard.p8
+++ b/c64/keyboard.p8
@@ -37,7 +37,7 @@ no_shift              ; otherwise clear keypress
       lda #$0
 
 check_k
-      sta keypress
+      sta p8_keypress
 
       ; Check for K
       lda #%11101111 ; Row 4 (PA4)
@@ -46,9 +46,9 @@ check_k
       and #%00100000 ; Col 5 (PB5)
 
       bne check_l
-      lda keypress
+      lda p8_keypress
       ora #$02
-      sta keypress
+      sta p8_keypress
 
       rts ; Return, we don't check for L
       
@@ -60,9 +60,9 @@ check_l
       and #%00000100 ; Col 2 (PB2)
 
       bne return
-      lda keypress
+      lda p8_keypress
       ora #$04
-      sta keypress
+      sta p8_keypress
 
 return
       rts

--- a/convert.p8
+++ b/convert.p8
@@ -19,7 +19,7 @@ convert {
       lsr a
       lsr a
       tay
-      lda convert.table,y
+      lda p8_convert.p8_table,y
     }}
   }
 
@@ -30,7 +30,7 @@ convert {
     %asm {{
       and #$0F
       tay
-      lda convert.table,y
+      lda p8_convert.p8_table,y
     }}
   }
 
@@ -46,7 +46,7 @@ convert {
   asmsub to_nibble(ubyte cnv @A) -> ubyte @A {
     %asm {{
         ldy  #6
--       cmp  table,y
+-       cmp  p8_table,y
         beq  +
         dey
         bpl  -

--- a/cx16/joystick.p8
+++ b/cx16/joystick.p8
@@ -24,16 +24,16 @@ joystick {
   ; Get joystick info from kernal to variables
   asmsub pull_info() clobbers(A, X, Y) {
     %asm {{
-      lda selected_joystick
+      lda p8_selected_joystick
       and #7
       jsr cx16.joystick_get
       eor #$ff               ; reverse bit pattern for easier testing
       cmp #$ff               ; Hack around NES keybord emulator issue
       beq skip_store         ; if all bits set assume skip setting joy_info
-      sta joy_info
+      sta p8_joy_info
 skip_store:
-      stx joy_info2
-      sty joy_info3
+      stx p8_joy_info2
+      sty p8_joy_info3
       rts
     }}
   }
@@ -61,9 +61,9 @@ skip_store:
       ; scan all joysticks to see if any presses fire, then choose that one
       for cx16.r0L in 4 downto 0 {
         cx16.r1 = cx16.joystick_get2(cx16.r0L)
-        if cx16.r1 & 192 != 192 {
+        if cx16.r1L & 192 != 192 {
            selected_joystick = cx16.r0L
-           return cx16.r1 & 192
+           return cx16.r1L & 192
         }
       }
     }

--- a/enemy.p8
+++ b/enemy.p8
@@ -289,23 +289,23 @@ enemy {
     ;   enemyRef[EN_SUBPOS] |= main.LEFTMOST
     ; }
     %asm {{
-      lda #main.LEFTMOST  ; check LEFTMOST (=1) is set
-      ldy #enemy.EN_SUBPOS
-      and (enemyRef),y    ; AND with EN_SUBPOS
+      lda #p8_main.p8_LEFTMOST  ; check LEFTMOST (=1) is set
+      ldy #p8_enemy.p8_EN_SUBPOS
+      and (p8_enemyRef),y    ; AND with EN_SUBPOS
       beq _move_left_else ;   and branch
-      lda (enemyRef),y    ; Get EN_SUBPOS
-      and #main.NOT_LEFTMOST ; AND with ~main.LEFTMOST
-      sta (enemyRef),y     
+      lda (p8_enemyRef),y    ; Get EN_SUBPOS
+      and #p8_main.p8_NOT_LEFTMOST ; AND with ~main.LEFTMOST
+      sta (p8_enemyRef),y     
       sec
-      ldy #enemy.EN_X
-      lda (enemyRef),y
+      ldy #p8_enemy.p8_EN_X
+      lda (p8_enemyRef),y
       sbc #1
-      sta (enemyRef),y
+      sta (p8_enemyRef),y
       rts
 _move_left_else
-      lda (enemyRef),y    ; Get EN_SUBPOS
-      ora #main.LEFTMOST  ; OR with main.LEFTMOST
-      sta (enemyRef),y
+      lda (p8_enemyRef),y    ; Get EN_SUBPOS
+      ora #p8_main.p8_LEFTMOST  ; OR with main.LEFTMOST
+      sta (p8_enemyRef),y
       rts
     }}
   }
@@ -318,23 +318,23 @@ _move_left_else
     ;   enemyRef[EN_X]++
     ; }
     %asm {{
-      lda #main.LEFTMOST  ; check LEFTMOST (=1) is set
-      ldy #enemy.EN_SUBPOS
-      and (enemyRef),y    ; AND with EN_SUBPOS
+      lda #p8_main.p8_LEFTMOST  ; check LEFTMOST (=1) is set
+      ldy #p8_enemy.p8_EN_SUBPOS
+      and (p8_enemyRef),y    ; AND with EN_SUBPOS
       beq _move_right_else;   and branch
-      lda (enemyRef),y    ; Get EN_SUBPOS
-      and #main.NOT_LEFTMOST ; AND with ~main.LEFTMOST
-      sta (enemyRef),y     
+      lda (p8_enemyRef),y    ; Get EN_SUBPOS
+      and #p8_main.p8_NOT_LEFTMOST ; AND with ~main.LEFTMOST
+      sta (p8_enemyRef),y     
       rts
 _move_right_else
-      lda (enemyRef),y    ; Get EN_SUBPOS
-      ora #main.LEFTMOST  ; OR with main.LEFTMOST
-      sta (enemyRef),y
+      lda (p8_enemyRef),y    ; Get EN_SUBPOS
+      ora #p8_main.p8_LEFTMOST  ; OR with main.LEFTMOST
+      sta (p8_enemyRef),y
       clc
-      ldy #enemy.EN_X
-      lda (enemyRef),y
+      ldy #p8_enemy.p8_EN_X
+      lda (p8_enemyRef),y
       adc #1
-      sta (enemyRef),y
+      sta (p8_enemyRef),y
       rts
     }}
   }
@@ -347,23 +347,23 @@ _move_right_else
     ;   enemyRef[EN_SUBPOS] |= main.TOPMOST
     ; }
     %asm {{
-      lda #main.TOPMOST   ; check TOPMOST (=2) is set
-      ldy #enemy.EN_SUBPOS
-      and (enemyRef),y    ; AND with EN_SUBPOS
+      lda #p8_main.p8_TOPMOST   ; check TOPMOST (=2) is set
+      ldy #p8_enemy.p8_EN_SUBPOS
+      and (p8_enemyRef),y    ; AND with EN_SUBPOS
       beq _move_up_else   ;   and branch
-      lda (enemyRef),y    ; Get EN_SUBPOS
-      and #main.NOT_TOPMOST ; AND with ~main.TOPMOST
-      sta (enemyRef),y     
+      lda (p8_enemyRef),y    ; Get EN_SUBPOS
+      and #p8_main.p8_NOT_TOPMOST ; AND with ~main.TOPMOST
+      sta (p8_enemyRef),y     
       sec
-      ldy #enemy.EN_Y
-      lda (enemyRef),y
+      ldy #p8_enemy.p8_EN_Y
+      lda (p8_enemyRef),y
       sbc #1
-      sta (enemyRef),y
+      sta (p8_enemyRef),y
       rts
 _move_up_else
-      lda (enemyRef),y    ; Get EN_SUBPOS
-      ora #main.TOPMOST   ; OR with main.TOPMOST
-      sta (enemyRef),y
+      lda (p8_enemyRef),y    ; Get EN_SUBPOS
+      ora #p8_main.p8_TOPMOST   ; OR with main.TOPMOST
+      sta (p8_enemyRef),y
       rts
     }}
   }
@@ -376,23 +376,23 @@ _move_up_else
     ;   enemyRef[EN_Y]++
     ; }
     %asm {{
-      lda #main.TOPMOST   ; check TOPMOST (=2) is set
-      ldy #enemy.EN_SUBPOS
-      and (enemyRef),y    ; AND with EN_SUBPOS
+      lda #p8_main.p8_TOPMOST   ; check TOPMOST (=2) is set
+      ldy #p8_enemy.p8_EN_SUBPOS
+      and (p8_enemyRef),y    ; AND with EN_SUBPOS
       beq _move_down_else ;   and branch
-      lda (enemyRef),y    ; Get EN_SUBPOS
-      and #main.NOT_TOPMOST ; AND with ~main.TOPMOST
-      sta (enemyRef),y     
+      lda (p8_enemyRef),y    ; Get EN_SUBPOS
+      and #p8_main.p8_NOT_TOPMOST ; AND with ~main.TOPMOST
+      sta (p8_enemyRef),y     
       rts
 _move_down_else
-      lda (enemyRef),y    ; Get EN_SUBPOS
-      ora #main.TOPMOST   ; OR with main.TOPMOST
-      sta (enemyRef),y
+      lda (p8_enemyRef),y    ; Get EN_SUBPOS
+      ora #p8_main.p8_TOPMOST   ; OR with main.TOPMOST
+      sta (p8_enemyRef),y
       clc
-      ldy #enemy.EN_Y
-      lda (enemyRef),y
+      ldy #p8_enemy.p8_EN_Y
+      lda (p8_enemyRef),y
       adc #1
-      sta (enemyRef),y
+      sta (p8_enemyRef),y
       rts
     }}
   }
@@ -406,11 +406,11 @@ _move_down_else
     ; txt.setcc(tmp_x+1, tmp_y+1, main.CLR, 1)
     ; txt.setcc(tmp_x,   tmp_y+1, main.CLR, 1)
    %asm {{
-      ldy #enemy.EN_X
-      lda (enemyRef),y
+      ldy #p8_enemy.p8_EN_X
+      lda (p8_enemyRef),y
       sta txt.setcc.column
-      ldy #enemy.EN_Y
-      lda (enemyRef),y
+      ldy #p8_enemy.p8_EN_Y
+      lda (p8_enemyRef),y
       sta txt.setcc.row
       lda #$20
       sta txt.setcc.char


### PR DESCRIPTION
Hi,
unfortunately we have to get past a backwards incompatible code generation change that is coming in Prog8 9.1 (not released yet!) 
 It is to avoid issues with translating prog8 symbols into assembly code: we decided to change the way symbols are translated into assembler.  [Details here.](https://prog8.readthedocs.io/en/latest/technical.html#symbol-prefixing-in-generated-assembly-code)

This PR contains the required changes to the inline asm code.

