### PR TITLE
Prog8 v9.4 fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,13 @@ now has the C64 running without noticable slowdowns.
 
 Compile/run for Commander X16 with something like this
 ```
-%JAVA_PATH% -jar prog8compiler-8.2-all.jar -srcdirs cx16 -target cx16 petaxian.p8
+%JAVA_PATH% -jar prog8compiler-9.4-all.jar -srcdirs cx16 -target cx16 petaxian.p8
 
 %X16EMU_PATH%\x16emu.exe -joy1 SNES -run -prg petaxian.prg
 ```
 and for C64 with e.g.
 ```
-%JAVA_PATH% -jar prog8compiler-8.2-all.jar -srcdirs c64 -target c64 petaxian.p8
+%JAVA_PATH% -jar prog8compiler-9.4-all.jar -srcdirs c64 -target c64 petaxian.p8
 
 %VICE_PATH%\x64sc.exe petaxian.prg
 ```

--- a/enemy.p8
+++ b/enemy.p8
@@ -408,20 +408,20 @@ _move_down_else
    %asm {{
       ldy #p8_enemy.p8_EN_X
       lda (p8_enemyRef),y
-      sta txt.setcc.column
+      sta txt.setcc.col
       ldy #p8_enemy.p8_EN_Y
       lda (p8_enemyRef),y
       sta txt.setcc.row
       lda #$20
-      sta txt.setcc.char
+      sta txt.setcc.character
       lda #$01
       sta txt.setcc.charcolor
       jsr txt.setcc
-      inc txt.setcc.column
+      inc txt.setcc.col
       jsr txt.setcc
       inc txt.setcc.row
       jsr txt.setcc
-      dec txt.setcc.column
+      dec txt.setcc.col
       jsr txt.setcc
     }}
   }


### PR DESCRIPTION
Some small changes were made in prog8 v9.4 to various variable names in the libraries to avoid assembler symbol shadowing warnings.  

Here are the adjustments needed to petaxian, because it contains some inlined assembly code that depended on the names because it is setting the parameter variables directly