### PR TITLE
adapt to the change in prog8 v9.7 irq handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,13 @@ now has the C64 running without noticable slowdowns.
 
 Compile/run for Commander X16 with something like this
 ```
-%JAVA_PATH% -jar prog8compiler-9.4-all.jar -srcdirs cx16 -target cx16 petaxian.p8
+%JAVA_PATH% -jar prog8compiler-9.7-all.jar -srcdirs cx16 -target cx16 petaxian.p8
 
 %X16EMU_PATH%\x16emu.exe -joy1 SNES -run -prg petaxian.prg
 ```
 and for C64 with e.g.
 ```
-%JAVA_PATH% -jar prog8compiler-9.4-all.jar -srcdirs c64 -target c64 petaxian.p8
+%JAVA_PATH% -jar prog8compiler-9.7-all.jar -srcdirs c64 -target c64 petaxian.p8
 
 %VICE_PATH%\x64sc.exe petaxian.prg
 ```

--- a/cx16/sound.p8
+++ b/cx16/sound.p8
@@ -8,7 +8,7 @@
 sound {
   sub init() {
     psg.silent()
-    sys.set_irq(psg.envelopes_irq, true)
+    sys.set_irq(&psg.envelopes_irq)
   }
 
   sub check() { ; Dummy function used on C64 only


### PR DESCRIPTION
If you'd like to build with prog8 version 9.7 or newer.

This change is not compatible with older versions of the compiler