### PR TITLE
changed asm symbol prefixes for Prog8 v10.0

### DIFF
--- a/c64/keyboard.p8
+++ b/c64/keyboard.p8
@@ -37,7 +37,7 @@ no_shift              ; otherwise clear keypress
       lda #$0
 
 check_k
-      sta p8_keypress
+      sta p8v_keypress
 
       ; Check for K
       lda #%11101111 ; Row 4 (PA4)
@@ -46,9 +46,9 @@ check_k
       and #%00100000 ; Col 5 (PB5)
 
       bne check_l
-      lda p8_keypress
+      lda p8v_keypress
       ora #$02
-      sta p8_keypress
+      sta p8v_keypress
 
       rts ; Return, we don't check for L
       
@@ -60,9 +60,9 @@ check_l
       and #%00000100 ; Col 2 (PB2)
 
       bne return
-      lda p8_keypress
+      lda p8v_keypress
       ora #$04
-      sta p8_keypress
+      sta p8v_keypress
 
 return
       rts

--- a/convert.p8
+++ b/convert.p8
@@ -19,7 +19,7 @@ convert {
       lsr a
       lsr a
       tay
-      lda p8_convert.p8_table,y
+      lda p8b_convert.p8v_table,y
     }}
   }
 
@@ -30,7 +30,7 @@ convert {
     %asm {{
       and #$0F
       tay
-      lda p8_convert.p8_table,y
+      lda p8b_convert.p8v_table,y
     }}
   }
 
@@ -46,7 +46,7 @@ convert {
   asmsub to_nibble(ubyte cnv @A) -> ubyte @A {
     %asm {{
         ldy  #6
--       cmp  p8_table,y
+-       cmp  p8v_table,y
         beq  +
         dey
         bpl  -

--- a/cx16/joystick.p8
+++ b/cx16/joystick.p8
@@ -24,16 +24,16 @@ joystick {
   ; Get joystick info from kernal to variables
   asmsub pull_info() clobbers(A, X, Y) {
     %asm {{
-      lda p8_selected_joystick
+      lda p8v_selected_joystick
       and #7
       jsr cx16.joystick_get
       eor #$ff               ; reverse bit pattern for easier testing
       cmp #$ff               ; Hack around NES keybord emulator issue
       beq skip_store         ; if all bits set assume skip setting joy_info
-      sta p8_joy_info
+      sta p8v_joy_info
 skip_store:
-      stx p8_joy_info2
-      sty p8_joy_info3
+      stx p8v_joy_info2
+      sty p8v_joy_info3
       rts
     }}
   }

--- a/enemy.p8
+++ b/enemy.p8
@@ -289,23 +289,23 @@ enemy {
     ;   enemyRef[EN_SUBPOS] |= main.LEFTMOST
     ; }
     %asm {{
-      lda #p8_main.p8_LEFTMOST  ; check LEFTMOST (=1) is set
-      ldy #p8_enemy.p8_EN_SUBPOS
-      and (p8_enemyRef),y    ; AND with EN_SUBPOS
+      lda #p8b_main.p8c_LEFTMOST  ; check LEFTMOST (=1) is set
+      ldy #p8b_enemy.p8c_EN_SUBPOS
+      and (p8v_enemyRef),y    ; AND with EN_SUBPOS
       beq _move_left_else ;   and branch
-      lda (p8_enemyRef),y    ; Get EN_SUBPOS
-      and #p8_main.p8_NOT_LEFTMOST ; AND with ~main.LEFTMOST
-      sta (p8_enemyRef),y     
+      lda (p8v_enemyRef),y    ; Get EN_SUBPOS
+      and #p8b_main.p8c_NOT_LEFTMOST ; AND with ~main.LEFTMOST
+      sta (p8v_enemyRef),y     
       sec
-      ldy #p8_enemy.p8_EN_X
-      lda (p8_enemyRef),y
+      ldy #p8b_enemy.p8c_EN_X
+      lda (p8v_enemyRef),y
       sbc #1
-      sta (p8_enemyRef),y
+      sta (p8v_enemyRef),y
       rts
 _move_left_else
-      lda (p8_enemyRef),y    ; Get EN_SUBPOS
-      ora #p8_main.p8_LEFTMOST  ; OR with main.LEFTMOST
-      sta (p8_enemyRef),y
+      lda (p8v_enemyRef),y    ; Get EN_SUBPOS
+      ora #p8b_main.p8c_LEFTMOST  ; OR with main.LEFTMOST
+      sta (p8v_enemyRef),y
       rts
     }}
   }
@@ -318,23 +318,23 @@ _move_left_else
     ;   enemyRef[EN_X]++
     ; }
     %asm {{
-      lda #p8_main.p8_LEFTMOST  ; check LEFTMOST (=1) is set
-      ldy #p8_enemy.p8_EN_SUBPOS
-      and (p8_enemyRef),y    ; AND with EN_SUBPOS
+      lda #p8b_main.p8c_LEFTMOST  ; check LEFTMOST (=1) is set
+      ldy #p8b_enemy.p8c_EN_SUBPOS
+      and (p8v_enemyRef),y    ; AND with EN_SUBPOS
       beq _move_right_else;   and branch
-      lda (p8_enemyRef),y    ; Get EN_SUBPOS
-      and #p8_main.p8_NOT_LEFTMOST ; AND with ~main.LEFTMOST
-      sta (p8_enemyRef),y     
+      lda (p8v_enemyRef),y    ; Get EN_SUBPOS
+      and #p8b_main.p8c_NOT_LEFTMOST ; AND with ~main.LEFTMOST
+      sta (p8v_enemyRef),y     
       rts
 _move_right_else
-      lda (p8_enemyRef),y    ; Get EN_SUBPOS
-      ora #p8_main.p8_LEFTMOST  ; OR with main.LEFTMOST
-      sta (p8_enemyRef),y
+      lda (p8v_enemyRef),y    ; Get EN_SUBPOS
+      ora #p8b_main.p8c_LEFTMOST  ; OR with main.LEFTMOST
+      sta (p8v_enemyRef),y
       clc
-      ldy #p8_enemy.p8_EN_X
-      lda (p8_enemyRef),y
+      ldy #p8b_enemy.p8c_EN_X
+      lda (p8v_enemyRef),y
       adc #1
-      sta (p8_enemyRef),y
+      sta (p8v_enemyRef),y
       rts
     }}
   }
@@ -347,23 +347,23 @@ _move_right_else
     ;   enemyRef[EN_SUBPOS] |= main.TOPMOST
     ; }
     %asm {{
-      lda #p8_main.p8_TOPMOST   ; check TOPMOST (=2) is set
-      ldy #p8_enemy.p8_EN_SUBPOS
-      and (p8_enemyRef),y    ; AND with EN_SUBPOS
+      lda #p8b_main.p8c_TOPMOST   ; check TOPMOST (=2) is set
+      ldy #p8b_enemy.p8c_EN_SUBPOS
+      and (p8v_enemyRef),y    ; AND with EN_SUBPOS
       beq _move_up_else   ;   and branch
-      lda (p8_enemyRef),y    ; Get EN_SUBPOS
-      and #p8_main.p8_NOT_TOPMOST ; AND with ~main.TOPMOST
-      sta (p8_enemyRef),y     
+      lda (p8v_enemyRef),y    ; Get EN_SUBPOS
+      and #p8b_main.p8c_NOT_TOPMOST ; AND with ~main.TOPMOST
+      sta (p8v_enemyRef),y     
       sec
-      ldy #p8_enemy.p8_EN_Y
-      lda (p8_enemyRef),y
+      ldy #p8b_enemy.p8c_EN_Y
+      lda (p8v_enemyRef),y
       sbc #1
-      sta (p8_enemyRef),y
+      sta (p8v_enemyRef),y
       rts
 _move_up_else
-      lda (p8_enemyRef),y    ; Get EN_SUBPOS
-      ora #p8_main.p8_TOPMOST   ; OR with main.TOPMOST
-      sta (p8_enemyRef),y
+      lda (p8v_enemyRef),y    ; Get EN_SUBPOS
+      ora #p8b_main.p8c_TOPMOST   ; OR with main.TOPMOST
+      sta (p8v_enemyRef),y
       rts
     }}
   }
@@ -376,23 +376,23 @@ _move_up_else
     ;   enemyRef[EN_Y]++
     ; }
     %asm {{
-      lda #p8_main.p8_TOPMOST   ; check TOPMOST (=2) is set
-      ldy #p8_enemy.p8_EN_SUBPOS
-      and (p8_enemyRef),y    ; AND with EN_SUBPOS
+      lda #p8b_main.p8c_TOPMOST   ; check TOPMOST (=2) is set
+      ldy #p8b_enemy.p8c_EN_SUBPOS
+      and (p8v_enemyRef),y    ; AND with EN_SUBPOS
       beq _move_down_else ;   and branch
-      lda (p8_enemyRef),y    ; Get EN_SUBPOS
-      and #p8_main.p8_NOT_TOPMOST ; AND with ~main.TOPMOST
-      sta (p8_enemyRef),y     
+      lda (p8v_enemyRef),y    ; Get EN_SUBPOS
+      and #p8b_main.p8c_NOT_TOPMOST ; AND with ~main.TOPMOST
+      sta (p8v_enemyRef),y     
       rts
 _move_down_else
-      lda (p8_enemyRef),y    ; Get EN_SUBPOS
-      ora #p8_main.p8_TOPMOST   ; OR with main.TOPMOST
-      sta (p8_enemyRef),y
+      lda (p8v_enemyRef),y    ; Get EN_SUBPOS
+      ora #p8b_main.p8c_TOPMOST   ; OR with main.TOPMOST
+      sta (p8v_enemyRef),y
       clc
-      ldy #p8_enemy.p8_EN_Y
-      lda (p8_enemyRef),y
+      ldy #p8b_enemy.p8c_EN_Y
+      lda (p8v_enemyRef),y
       adc #1
-      sta (p8_enemyRef),y
+      sta (p8v_enemyRef),y
       rts
     }}
   }
@@ -406,11 +406,11 @@ _move_down_else
     ; txt.setcc(tmp_x+1, tmp_y+1, main.CLR, 1)
     ; txt.setcc(tmp_x,   tmp_y+1, main.CLR, 1)
    %asm {{
-      ldy #p8_enemy.p8_EN_X
-      lda (p8_enemyRef),y
+      ldy #p8b_enemy.p8c_EN_X
+      lda (p8v_enemyRef),y
       sta txt.setcc.col
-      ldy #p8_enemy.p8_EN_Y
-      lda (p8_enemyRef),y
+      ldy #p8b_enemy.p8c_EN_Y
+      lda (p8v_enemyRef),y
       sta txt.setcc.row
       lda #$20
       sta txt.setcc.character


### PR DESCRIPTION
Unfortunately, symbol naming conflicts in generated assembly code once again needed a change in the way prog8 symbols are prefixed into assembly. This will appear in the next prog8 version, v10.0

We did this before in #20 , but that wasn't enough.

So here are the necessary changes.

... but I wonder, I think most of the assembly code is perhaps not even needed anymore? I think it was written to get acceptable speed on the C64, but I'm pretty sure nowadays you can achieve that with a lot less hand written assembly.  