### PR TITLE
New syntax rules for multi-assigns/multi-value returns

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,13 @@ now has the C64 running without noticable slowdowns.
 
 Compile/run for Commander X16 with something like this
 ```
-%JAVA_PATH% -jar prog8compiler-9.7-all.jar -srcdirs cx16 -target cx16 petaxian.p8
+%JAVA_PATH% -jar prog8compiler-10.3-all.jar -srcdirs cx16 -target cx16 petaxian.p8
 
 %X16EMU_PATH%\x16emu.exe -joy1 SNES -run -prg petaxian.prg
 ```
 and for C64 with e.g.
 ```
-%JAVA_PATH% -jar prog8compiler-9.7-all.jar -srcdirs c64 -target c64 petaxian.p8
+%JAVA_PATH% -jar prog8compiler-10.3-all.jar -srcdirs c64 -target c64 petaxian.p8
 
 %VICE_PATH%\x64sc.exe petaxian.prg
 ```

--- a/cx16/joystick.p8
+++ b/cx16/joystick.p8
@@ -44,7 +44,7 @@ skip_store:
     if selected_joystick == 128 {
       ; scan all joysticks to see if any presses start, then choose that one
       for cx16.r0L in 4 downto 0 {
-        cx16.r1 = cx16.joystick_get2(cx16.r0L)
+        cx16.r1, void = cx16.joystick_get(cx16.r0L)
         if cx16.r1 & 16 == 0 {
            selected_joystick = cx16.r0L
            return true
@@ -60,7 +60,7 @@ skip_store:
     if selected_joystick==128 {
       ; scan all joysticks to see if any presses fire, then choose that one
       for cx16.r0L in 4 downto 0 {
-        cx16.r1 = cx16.joystick_get2(cx16.r0L)
+        cx16.r1, void = cx16.joystick_get(cx16.r0L)
         if cx16.r1L & 192 != 192 {
            selected_joystick = cx16.r0L
            return true

--- a/cx16/keyboard.p8
+++ b/cx16/keyboard.p8
@@ -16,7 +16,7 @@ keyboard {
   ubyte key
 
   sub pull_info() {
-    key = cbm.GETIN()
+    key = cbm.GETIN2()
   }
 
   sub pushing_fire() -> bool {

--- a/petaxian.p8
+++ b/petaxian.p8
@@ -255,7 +255,7 @@ endloop:
 
     ubyte inp = 0
     while inp != key {
-       inp = cbm.GETIN()
+       inp = cbm.GETIN2()
        if time_lo >= 2 {
          cbm.SETTIM(0,0,0)
          write( colRef[col], x, y, strRef )


### PR DESCRIPTION
Prog8 version 10.3 (still in development) will have stricter rules about how to deal with (asm)subroutine calls returning mulitple values. A few tweaks related to this have been made to a couple of library routines as well.

This PR contains the required changes to Petaxian to make it compile again with 10.3 once released.  Note that these changes are not backwards compatible