### PR TITLE
fix asm subroutine to properly return at the end

### DIFF
--- a/enemy.p8
+++ b/enemy.p8
@@ -422,7 +422,7 @@ _move_down_else
       inc txt.setcc.row
       jsr txt.setcc
       dec txt.setcc.col
-      jsr txt.setcc
+      jmp txt.setcc
     }}
   }
 


### PR DESCRIPTION
the assembly subroutine should end with a JMP rather than an JSR , to properly return to the caller.

This was fixed automatically by the prog8 compiler, however, that silent modifying behavior is going away in the next version (10.5) and so the user has to correct the code now.

Alternatively, for a limited time, the old behavior can be enabled by compiling with the "-addmissingrts" command line option, but that option will go away too in a future version.